### PR TITLE
Improvement: abstract and inject ratelimiter depedencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ compatible autoloader.
 
 ```php
 // 1. Make a rate limiter with limit 3 attempts in 10 minutes
-$adapter = new DesarrollaCacheAdapter((new DesarrollaCacheFactory())->make());
+$cacheAdapter = new DesarrollaCacheAdapter((new DesarrollaCacheFactory())->make());
 $ratelimiter = new RateLimiter(new ThrottlerFactory(), new HydratorFactory(), $cacheAdapter, 3, 600);
 
 // 2. Get a throttler for path /login 
@@ -71,12 +71,11 @@ You can configure the drivers in ```config.php```, for example to use memcache c
 
 ```php
 return [
-    'adapter'    => 'desarrolla',
-    'desarrolla' => [
-        'default_ttl' => 3600,
-        'driver'      => 'memcache',
+    'default_ttl' => 3600,
+    'driver'      => 'memcache',
+    'memcache' => [
         //....
-    ]
+    ],
 ];
 ```
 
@@ -124,12 +123,16 @@ $hydrator = new RequestHydrator();
 Then decorate or extend the HydratorFactory to recognize your data
 
 ```php
-class MyHydratorFactory impements Hydrator\FactoryInterface
+use Hydrator\FactoryInterface;
+
+class MyHydratorFactory implements FactoryInterface
 {
-    /**
-     * Hydrator\FactoryInterface
-     */
     private $defaultFactory;
+
+    public function __construct(FactoryInterface $defaultFactory)
+    {
+        $this->defaultFactory = $defaultFactory;
+    }
 
     public function make($data)
     {
@@ -137,7 +140,7 @@ class MyHydratorFactory impements Hydrator\FactoryInterface
             return new RequestHydrator();
         }
 
-        return $defaultFactory->make($data);
+        return $this->defaultFactory->make($data);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ compatible autoloader.
 
 ```php
 // 1. Make a rate limiter with limit 3 attempts in 10 minutes
-$ratelimiter = new RateLimiter(3, 600);
+$adapter = new DesarrollaCacheAdapter((new DesarrollaCacheFactory())->make());
+$ratelimiter = new RateLimiter(new ThrottlerFactory(), new HydratorFactory(), $cacheAdapter, 3, 600);
 
 // 2. Get a throttler for path /login 
 $loginThrottler = $ratelimiter->get('/login');
@@ -118,13 +119,29 @@ class RequestHydrator implements DataHydratorInterface
 
 // Hydrate the request to Data object
 $hydrator = new RequestHydrator();
-$data = $hydrator->hydrate(new \Symfony\Component\HttpFoundation\Request(), 3, 600);
-
-$factory = new ThrottlerFactory();
-$requestThrottler = $factory->make($data, $adapter);
-
-// Now you have the request throttler
 ```
+
+Then decorate or extend the HydratorFactory to recognize your data
+
+```php
+class MyHydratorFactory impements Hydrator\FactoryInterface
+{
+    /**
+     * Hydrator\FactoryInterface
+     */
+    private $defaultFactory;
+
+    public function make($data)
+    {
+        if ($data instanceof Request) {
+            return new RequestHydrator();
+        }
+
+        return $defaultFactory->make($data);
+    }
+}
+```
+
 ## Author
 
 Krishnaprasad MG [@sunspikes]

--- a/config/config.php
+++ b/config/config.php
@@ -4,36 +4,33 @@
  */
 
 return [
-    'adapter'    => 'desarrolla',
-    'desarrolla' => [
-        'default_ttl' => 3600,
-        'driver'      => 'notcache',
-        'notcache'    => [
-            // config for not cache
-        ],
-        'file'        => [
-            'cache_dir' => './data',
-        ],
-        'apc'         => [
-            // config for apc
-        ],
-        'memory'      => [
-            'limit' => 1000,
-        ],
-        'mongo'       => [
-            'server' => 'mongodb://localhost:27017',
-        ],
-        'mysql'       => [
-            'host'     => '127.0.0.1',
-            'username' => 'root',
-            'password' => '',
-            'port'     => 3306
-        ],
-        'redis'       => [
-            // config for redis
-        ],
-        'memcache'    => [
-            // config for memcache
-        ],
-    ]
+    'default_ttl' => 3600,
+    'driver'      => 'notcache',
+    'notcache'    => [
+        // config for not cache
+    ],
+    'file'        => [
+        'cache_dir' => './data',
+    ],
+    'apc'         => [
+        // config for apc
+    ],
+    'memory'      => [
+       'limit' => 1000,
+    ],
+    'mongo'       => [
+        'server' => 'mongodb://localhost:27017',
+    ],
+    'mysql'       => [
+        'host'     => '127.0.0.1',
+        'username' => 'root',
+        'password' => '',
+        'port'     => 3306
+    ],
+    'redis'       => [
+        // config for redis
+    ],
+    'memcache'    => [
+        // config for memcache
+    ],
 ];

--- a/src/Cache/Factory/DesarrollaCacheFactory.php
+++ b/src/Cache/Factory/DesarrollaCacheFactory.php
@@ -48,20 +48,38 @@ class DesarrollaCacheFactory implements FactoryInterface
     protected $config;
 
     /**
+     * @param string|null $configFile
+     * @param array       $configArray
+     */
+    public function __construct($configFile = null, array $configArray = [])
+    {
+        // Default config from distribution
+        if (null === $configFile) {
+            $configFile = __DIR__.'/../../../config/config.php';
+        }
+
+        $config = include $configFile;
+
+        if (!isset($config['adapter']) || !isset($config['desarrolla']) || 'desarrolla' !== $config['adapter']) {
+            throw new \InvalidArgumentException('Invalid adapter found, please check your config.');
+        }
+
+        $this->config = array_merge($config['desarrolla'], $configArray);
+    }
+
+    /**
      * @inheritdoc
      */
-    public function make($config)
+    public function make()
     {
-        $this->config = $config['desarrolla'];
-        $driver = $this->getDriver();
-
-        return new Cache($driver);
+        return new Cache($this->getDriver());
     }
 
     /**
      * Make the driver based on given config
      *
      * @return null|\Desarrolla2\Cache\Adapter\AdapterInterface
+     *
      * @throws DriverNotFoundException
      * @throws InvalidConfigException
      */

--- a/src/Cache/Factory/DesarrollaCacheFactory.php
+++ b/src/Cache/Factory/DesarrollaCacheFactory.php
@@ -60,11 +60,7 @@ class DesarrollaCacheFactory implements FactoryInterface
 
         $config = include $configFile;
 
-        if (!isset($config['adapter']) || !isset($config['desarrolla']) || 'desarrolla' !== $config['adapter']) {
-            throw new \InvalidArgumentException('Invalid adapter found, please check your config.');
-        }
-
-        $this->config = array_merge($config['desarrolla'], $configArray);
+        $this->config = array_merge($config, $configArray);
     }
 
     /**

--- a/src/Cache/Factory/FactoryInterface.php
+++ b/src/Cache/Factory/FactoryInterface.php
@@ -30,9 +30,7 @@ interface FactoryInterface
     /**
      * Create a cache driver adapter
      *
-     * @param array $config
-     *
      * @return mixed
      */
-    public function make($config);
+    public function make();
 }

--- a/src/Throttle/Hydrator/FactoryInterface.php
+++ b/src/Throttle/Hydrator/FactoryInterface.php
@@ -28,23 +28,19 @@ namespace Sunspikes\Ratelimit\Throttle\Hydrator;
 use Sunspikes\Ratelimit\Throttle\Exception\InvalidDataTypeException;
 
 /**
- * @inheritdoc
+ * This is the hydrator factory class.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
  */
-class HydratorFactory implements FactoryInterface
+interface FactoryInterface
 {
     /**
-     * @inheritdoc
+     * Create a hydrator
+     *
+     * @param mixed $data
+     *
+     * @return DataHydratorInterface
+     * @throws InvalidDataTypeException
      */
-    public function make($data)
-    {
-        if (is_string($data)) {
-            return new StringHydrator();
-        }
-
-        if (is_array($data)) {
-            return new ArrayHydrator();
-        }
-
-        throw new InvalidDataTypeException('Data type not supported, please check the data.');
-    }
+    public function make($data);
 }

--- a/tests/Cache/Factory/DesarrollaCacheFactoryTest.php
+++ b/tests/Cache/Factory/DesarrollaCacheFactoryTest.php
@@ -8,17 +8,8 @@ class DesarrollaCacheFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testFactory()
     {
-        $config = [
-            'adapter' => 'desarrolla',
-            'desarrolla' => [
-                'driver' => 'notcache',
-                'default_ttl' => 3600,
-                'notcache' => [],
-            ],
-        ];
-
         $factory = new DesarrollaCacheFactory();
-        $cache = $factory->make($config);
+        $cache = $factory->make();
 
         $this->assertInstanceOf('\Desarrolla2\Cache\Cache', $cache);
     }

--- a/tests/RatelimiterTest.php
+++ b/tests/RatelimiterTest.php
@@ -3,19 +3,39 @@
 namespace Sunspikes\Tests\Ratelimit;
 
 use Mockery as M;
+use Sunspikes\Ratelimit\Cache\Adapter\CacheAdapterInterface;
+use Sunspikes\Ratelimit\Cache\Exception\ItemNotFoundException;
 use Sunspikes\Ratelimit\RateLimiter;
+use Sunspikes\Ratelimit\Throttle\Factory\ThrottlerFactory;
+use Sunspikes\Ratelimit\Throttle\Hydrator\HydratorFactory;
 
 class RatelimiterTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var CacheAdapterInterface|M\MockInterface
+     */
+    private $mockCacheAdapter;
+
+    /**
+     * @var RateLimiter
+     */
     private $ratelimiter;
 
     public function setUp()
     {
-        $this->ratelimiter = new RateLimiter(3, 600);
+        $throttlerFactory = new ThrottlerFactory();
+        $hydratorFactory =  new HydratorFactory();
+        $this->mockCacheAdapter = M::mock(CacheAdapterInterface::class);
+
+        $this->ratelimiter = new RateLimiter($throttlerFactory, $hydratorFactory, $this->mockCacheAdapter, 3, 600);
     }
 
     public function testThrottlePreLimit()
     {
+        $this->mockCacheAdapter->shouldReceive('set')->times(2);
+        $this->mockCacheAdapter->shouldReceive('get')->once()->andThrow(ItemNotFoundException::class);
+        $this->mockCacheAdapter->shouldReceive('get')->once()->andReturn(2);
+
         $throttle = $this->ratelimiter->get('pre-limit-test');
         $throttle->hit();
         $throttle->hit();
@@ -25,6 +45,10 @@ class RatelimiterTest extends \PHPUnit_Framework_TestCase
 
     public function testThrottlePostLimit()
     {
+        $this->mockCacheAdapter->shouldReceive('set')->times(3);
+        $this->mockCacheAdapter->shouldReceive('get')->once()->andThrow(ItemNotFoundException::class);
+        $this->mockCacheAdapter->shouldReceive('get')->twice()->andReturn(2, 3);
+
         $throttle = $this->ratelimiter->get('post-limit-test');
         $throttle->hit();
         $throttle->hit();
@@ -35,6 +59,10 @@ class RatelimiterTest extends \PHPUnit_Framework_TestCase
 
     public function testThrottleAccess()
     {
+        $this->mockCacheAdapter->shouldReceive('set')->times(4);
+        $this->mockCacheAdapter->shouldReceive('get')->once()->andThrow(ItemNotFoundException::class);
+        $this->mockCacheAdapter->shouldReceive('get')->times(3)->andReturn(2, 3, 4);
+
         $throttle = $this->ratelimiter->get('access-test');
         $throttle->access();
         $throttle->access();
@@ -45,6 +73,10 @@ class RatelimiterTest extends \PHPUnit_Framework_TestCase
 
     public function testThrottleCount()
     {
+        $this->mockCacheAdapter->shouldReceive('set')->times(3);
+        $this->mockCacheAdapter->shouldReceive('get')->once()->andThrow(ItemNotFoundException::class);
+        $this->mockCacheAdapter->shouldReceive('get')->times(3)->andReturn(2, 3, 3);
+
         $throttle = $this->ratelimiter->get('count-test');
         $throttle->access();
         $throttle->access();


### PR DESCRIPTION
The goal of this PR is to improve flexibility. With these changes, the `Ratelimiter` class can be used with custom hydrators, throttlers and/or cacheadapter.

Changes:
- Interfaced & injected the hydrator factory
- Config has been moved to the cache factory, since it is only used there. This simplifies the `Ratelimiter` class
- Global ratelimiter `limit` & `ttl` are no longer overwritten when fetching a new throttler
