### PR TITLE
Fix used config indices and update Desarrolla cache package to ~2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "desarrolla2/cache": "~1.8"
+        "desarrolla2/cache": "~2.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.4",

--- a/config/config.php
+++ b/config/config.php
@@ -25,6 +25,7 @@ return [
         'host'     => '127.0.0.1',
         'username' => 'root',
         'password' => '',
+        'dbname'   => '',
         'port'     => 3306
     ],
     'redis'       => [

--- a/config/config.php
+++ b/config/config.php
@@ -31,6 +31,8 @@ return [
         // config for redis
     ],
     'memcache'    => [
-        // config for memcache
+        'servers' => [
+            'localhost'
+        ]
     ],
 ];

--- a/src/Cache/Factory/DesarrollaCacheFactory.php
+++ b/src/Cache/Factory/DesarrollaCacheFactory.php
@@ -172,6 +172,7 @@ class DesarrollaCacheFactory implements FactoryInterface
                 $this->config['mysql']['host'],
                 $this->config['mysql']['username'],
                 $this->config['mysql']['password'],
+                $this->config['mysql']['dbname'],
                 $this->config['mysql']['port']
             );
         }

--- a/src/Cache/Factory/DesarrollaCacheFactory.php
+++ b/src/Cache/Factory/DesarrollaCacheFactory.php
@@ -25,14 +25,14 @@
 
 namespace Sunspikes\Ratelimit\Cache\Factory;
 
-use Desarrolla2\Cache\Adapter\Apc;
+use Desarrolla2\Cache\Adapter\Apcu;
 use Desarrolla2\Cache\Adapter\File;
-use Desarrolla2\Cache\Adapter\MemCache;
+use Desarrolla2\Cache\Adapter\Memcache;
 use Desarrolla2\Cache\Adapter\Memory;
 use Desarrolla2\Cache\Adapter\Mongo;
-use Desarrolla2\Cache\Adapter\MySQL;
+use Desarrolla2\Cache\Adapter\Mysqli;
 use Desarrolla2\Cache\Adapter\NotCache;
-use Desarrolla2\Cache\Adapter\Redis;
+use Desarrolla2\Cache\Adapter\Predis;
 use Desarrolla2\Cache\Cache;
 use Sunspikes\Ratelimit\Cache\Exception\DriverNotFoundException;
 use Sunspikes\Ratelimit\Cache\Exception\InvalidConfigException;
@@ -119,30 +119,29 @@ class DesarrollaCacheFactory implements FactoryInterface
      */
     protected function createFileDriver()
     {
-        return new File($this->config['cache_dir']);
+        return new File($this->config['file']['cache_dir']);
     }
 
     /**
      * Create APC driver
      *
-     * @return Apc
+     * @return Apcu
      */
     protected function createApcDriver()
     {
-        return new Apc();
+        return new Apcu();
     }
 
     /**
      * Create Memory driver
      *
      * @return Memory
-     * @throws \Desarrolla2\Cache\Adapter\MemoryCacheException
      */
     protected function createMemoryDriver()
     {
         $memory = new Memory();
         $memory->setOption('limit',
-            $this->config['limit']
+            $this->config['memory']['limit']
                 ?: static::DEFAULT_LIMIT
         );
 
@@ -156,32 +155,38 @@ class DesarrollaCacheFactory implements FactoryInterface
      */
     protected function createMongoDriver()
     {
-        return new Mongo($this->config['server']);
+        return new Mongo($this->config['mongo']['server']);
     }
 
     /**
      * Create MySQL driver
      *
-     * @return MySQL
+     * @return Mysqli
      */
     protected function createMysqlDriver()
     {
-        return new MySQL(
-            $this->config['host'],
-            $this->config['username'],
-            $this->config['password'],
-            $this->config['port']
-        );
+        $server = null;
+
+        if (!empty($this->config['mysql'])) {
+            $server = new \mysqli(
+                $this->config['mysql']['host'],
+                $this->config['mysql']['username'],
+                $this->config['mysql']['password'],
+                $this->config['mysql']['port']
+            );
+        }
+
+        return new Mysqli($server);
     }
 
     /**
      * Create Redis driver
      *
-     * @return Redis
+     * @return Predis
      */
     protected function createRedisDriver()
     {
-        return new Redis();
+        return new Predis();
     }
 
     /**
@@ -191,6 +196,16 @@ class DesarrollaCacheFactory implements FactoryInterface
      */
     protected function createMemcacheDriver()
     {
-        return new MemCache();
+        $server = null;
+
+        if (isset($this->config['servers'])) {
+            $server = new \Memcache();
+
+            foreach ($this->config['servers'] as $host) {
+                $server->addserver($host);
+            }
+        }
+
+        return new Memcache($server);
     }
 }

--- a/tests/Cache/Factory/DesarrollaCacheFactoryTest.php
+++ b/tests/Cache/Factory/DesarrollaCacheFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Sunspikes\Tests\Ratelimit\Cache\Factory;
 
+use Desarrolla2\Cache\Cache;
 use Sunspikes\Ratelimit\Cache\Factory\DesarrollaCacheFactory;
 
 class DesarrollaCacheFactoryTest extends \PHPUnit_Framework_TestCase
@@ -11,6 +12,37 @@ class DesarrollaCacheFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new DesarrollaCacheFactory();
         $cache = $factory->make();
 
-        $this->assertInstanceOf('\Desarrolla2\Cache\Cache', $cache);
+        $this->assertInstanceOf(Cache::class, $cache);
+    }
+
+    /**
+     * @dataProvider configProvider
+     *
+     * @param array $config
+     */
+    public function testCreateDrivers(array $config, $driverClass)
+    {
+        if (null !== $driverClass && !class_exists($driverClass)) {
+            $this->markTestSkipped($driverClass.' is not available on this system');
+        }
+
+        $factory = new DesarrollaCacheFactory(null, $config);
+        $this->assertInstanceOf(Cache::class, $factory->make());
+    }
+
+    /**
+     * @return array
+     */
+    public function configProvider()
+    {
+        return [
+            [['driver' => 'file'], null],
+            [['driver' => 'apc'], null],
+            [['driver' => 'memory'], null],
+            [['driver' => 'mongo'], \MongoClient::class],
+            [['driver' => 'redis'], \Predis\Client::class],
+            [['driver' => 'mysql', 'mysql' => []], \mysqli::class],
+            [['driver' => 'memcache'], \Memcache::class],
+        ];
     }
 }


### PR DESCRIPTION
Hi there, another PR to address a couple issues I ran into: 
- In the Desarrolla cache package v1.8, the `MemCache` driver always adds localhost as a server. This will result in errors if memcache is run elsewhere. This has been corrected in v2.0, thus the package update.
- The `DesarrollaCacheFactory` used incorrect config indices for some adapters. This has been corrected, and I've added some tests for these functions (skipping those for which the required depedency is not available locally)
