### PR TITLE
Added ItemNotFoundException to CacheAdapterInterface

### DIFF
--- a/src/Cache/Adapter/CacheAdapterInterface.php
+++ b/src/Cache/Adapter/CacheAdapterInterface.php
@@ -25,6 +25,8 @@
 
 namespace Sunspikes\Ratelimit\Cache\Adapter;
 
+use Sunspikes\Ratelimit\Cache\Exception\ItemNotFoundException;
+
 interface CacheAdapterInterface
 {
     /**
@@ -33,6 +35,8 @@ interface CacheAdapterInterface
      * @param string $key
      *
      * @return mixed
+     * 
+     * @throws ItemNotFoundException
      */
     public function get($key);
 


### PR DESCRIPTION
Since classes using the CacheAdapter depend on this behaviour, any alternative implementation should throw this exception as well