### PR TITLE
Fix PHP8 return type incompatibility

### DIFF
--- a/src/Throttle/Throttler/AbstractWindowThrottler.php
+++ b/src/Throttle/Throttler/AbstractWindowThrottler.php
@@ -128,5 +128,5 @@ abstract class AbstractWindowThrottler
     /**
      * @inheritdoc
      */
-    abstract public function count();
+    abstract public function count(): int;
 }

--- a/src/Throttle/Throttler/ElasticWindowThrottler.php
+++ b/src/Throttle/Throttler/ElasticWindowThrottler.php
@@ -94,7 +94,7 @@ class ElasticWindowThrottler implements RetriableThrottlerInterface, \Countable
     /**
      * @inheritdoc
      */
-    public function count()
+    public function count(): int
     {
         if (!is_null($this->counter)) {
             return $this->counter;

--- a/src/Throttle/Throttler/FixedWindowThrottler.php
+++ b/src/Throttle/Throttler/FixedWindowThrottler.php
@@ -59,7 +59,7 @@ final class FixedWindowThrottler extends AbstractWindowThrottler implements Retr
     /**
      * @inheritdoc
      */
-    public function count()
+    public function count(): int
     {
         try {
             if (($this->timeProvider->now() - $this->cache->get($this->getTimeCacheKey())) > $this->timeLimit) {

--- a/src/Throttle/Throttler/LeakyBucketThrottler.php
+++ b/src/Throttle/Throttler/LeakyBucketThrottler.php
@@ -131,7 +131,7 @@ final class LeakyBucketThrottler implements RetriableThrottlerInterface
     /**
      * @inheritdoc
      */
-    public function count()
+    public function count(): int
     {
         try {
             $cachedTime = $this->cache->get($this->getTimeCacheKey());

--- a/src/Throttle/Throttler/MovingWindowThrottler.php
+++ b/src/Throttle/Throttler/MovingWindowThrottler.php
@@ -58,7 +58,7 @@ final class MovingWindowThrottler extends AbstractWindowThrottler implements Ret
     /**
      * @inheritdoc
      */
-    public function count()
+    public function count(): int
     {
         $this->updateHitCount();
 

--- a/src/Throttle/Throttler/RetrialQueueThrottler.php
+++ b/src/Throttle/Throttler/RetrialQueueThrottler.php
@@ -83,7 +83,7 @@ final class RetrialQueueThrottler implements ThrottlerInterface
     /**
      * @inheritdoc
      */
-    public function count()
+    public function count(): int
     {
         return $this->internalThrottler->count();
     }

--- a/src/Throttle/Throttler/ThrottlerInterface.php
+++ b/src/Throttle/Throttler/ThrottlerInterface.php
@@ -56,7 +56,7 @@ interface ThrottlerInterface
      *
      * @return int
      */
-    public function count();
+    public function count(): int;
 
     /**
      * Check the throttle status


### PR DESCRIPTION
This change fixes the fatal error when running this library on PHP >= 8.0 (since the [more strict LSP rules](https://php.watch/versions/8.0/lsp-errors)). Simply have added the correct return types to the count() methods to resolve.